### PR TITLE
Add ASM and C compile scripts

### DIFF
--- a/Compile-Scripts for C and Assembly/Anleitung.md
+++ b/Compile-Scripts for C and Assembly/Anleitung.md
@@ -1,0 +1,15 @@
+# RO-Shellscripts
+
+## Benutzung
+
+### Assembler:
+
+```
+bash AssemblerCompiler.sh AufgabeXY.s
+```
+### C:
+```
+bash CCompiler.sh AufgabeXY.c
+```
+
+Credit: Thobbe42 on github

--- a/Compile-Scripts for C and Assembly/Anleitung.md
+++ b/Compile-Scripts for C and Assembly/Anleitung.md
@@ -2,6 +2,9 @@
 
 ## Benutzung
 
+**Warnung**: 
+Nicht verwenden zusammen mit scanf oder anderen funktionen die user interaktion benötigen! 
+
 ### Assembler:
 
 ```

--- a/Compile-Scripts for C and Assembly/AssemblerCompiler.sh
+++ b/Compile-Scripts for C and Assembly/AssemblerCompiler.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+file="$1"
+bname=$(basename -s .s "${file}")
+arm-linux-gnueabihf-as -o "${bname}".o "${file}"
+arm-linux-gnueabihf-gcc -o "${bname}" "${bname}".o
+./${bname} ; echo $?
+

--- a/Compile-Scripts for C and Assembly/CCompiler.sh
+++ b/Compile-Scripts for C and Assembly/CCompiler.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+file="$1"
+bname=$(basename -s .c "${file}")
+gcc -o "${bname}" "${file}"
+./${bname}
+


### PR DESCRIPTION
These  shell scripts reduce the effort to use compile and execute the C and ASM code that the students need to write, by automating the commands and automatically executing the program.
The _Anleitung.md_ File explains how the commands are used and when not to use them